### PR TITLE
Solar and Lunar Rework

### DIFF
--- a/src/main/java/am2/api/spell/component/interfaces/ISpellModifier.java
+++ b/src/main/java/am2/api/spell/component/interfaces/ISpellModifier.java
@@ -34,8 +34,9 @@ public interface ISpellModifier extends ISpellPart{
 	 * @param spellStack The itemstack comprising the spell (in case you want to base it on other modifiers added)
 	 * @param stage      The stage in which this modifier has been added (if the modifier is added to multiple stages, this will be called multiple times, once per stage)
 	 * @param quantity   The quantity of this multiplier in the specified stage.
+	 * @param caster   The caster.
 	 */
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity);
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster);
 
 	/**
 	 * Gets any metadata needed by this modifier for the current spell.  Used, for example, in the color modifier to determine what color was specified.

--- a/src/main/java/am2/spell/SpellUtils.java
+++ b/src/main/java/am2/spell/SpellUtils.java
@@ -401,7 +401,7 @@ public class SpellUtils implements ISpellUtils{
 			}
 
 			for (ISpellModifier modifier : modifierWithQuantity.keySet()){
-				stageManaCost *= modifier.getManaCostMultiplier(stack, i, modifierWithQuantity.get(modifier));
+				stageManaCost *= modifier.getManaCostMultiplier(stack, i, modifierWithQuantity.get(modifier), caster);
 			}
 
 			manaCost += (stageManaCost * shape.manaCostMultiplier(stack));

--- a/src/main/java/am2/spell/modifiers/Bounce.java
+++ b/src/main/java/am2/spell/modifiers/Bounce.java
@@ -37,7 +37,7 @@ public class Bounce implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/BuffPower.java
+++ b/src/main/java/am2/spell/modifiers/BuffPower.java
@@ -41,7 +41,7 @@ public class BuffPower implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Cloaking.java
+++ b/src/main/java/am2/spell/modifiers/Cloaking.java
@@ -41,7 +41,7 @@ public class Cloaking implements ISpellModifier {
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.2F * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Colour.java
+++ b/src/main/java/am2/spell/modifiers/Colour.java
@@ -40,7 +40,7 @@ public class Colour implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.0f;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Damage.java
+++ b/src/main/java/am2/spell/modifiers/Damage.java
@@ -39,7 +39,7 @@ public class Damage implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.3f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Dismembering.java
+++ b/src/main/java/am2/spell/modifiers/Dismembering.java
@@ -37,7 +37,7 @@ public class Dismembering implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Duration.java
+++ b/src/main/java/am2/spell/modifiers/Duration.java
@@ -36,7 +36,7 @@ public class Duration implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/FeatherTouch.java
+++ b/src/main/java/am2/spell/modifiers/FeatherTouch.java
@@ -38,7 +38,7 @@ public class FeatherTouch implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Gravity.java
+++ b/src/main/java/am2/spell/modifiers/Gravity.java
@@ -37,7 +37,7 @@ public class Gravity implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Healing.java
+++ b/src/main/java/am2/spell/modifiers/Healing.java
@@ -39,7 +39,7 @@ public class Healing implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1 * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Homing.java
+++ b/src/main/java/am2/spell/modifiers/Homing.java
@@ -39,7 +39,7 @@ public class Homing implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.5f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/KeystoneRecognition.java
+++ b/src/main/java/am2/spell/modifiers/KeystoneRecognition.java
@@ -39,7 +39,7 @@ public class KeystoneRecognition implements ISpellModifier {
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.0f;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Lingering.java
+++ b/src/main/java/am2/spell/modifiers/Lingering.java
@@ -41,7 +41,7 @@ public class Lingering implements ISpellModifier {
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 2F * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Lunar.java
+++ b/src/main/java/am2/spell/modifiers/Lunar.java
@@ -3,6 +3,9 @@ package am2.spell.modifiers;
 import am2.api.spell.component.interfaces.ISpellModifier;
 import am2.api.spell.enums.SpellModifiers;
 import am2.items.ItemsCommonProxy;
+import am2.playerextensions.ExtendedProperties;
+import am2.spell.SpellHelper;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Items;
@@ -12,7 +15,6 @@ import net.minecraft.world.World;
 import java.util.EnumSet;
 
 public class Lunar implements ISpellModifier{
-
 	@Override
 	public int getID(){
 		return 10;
@@ -26,36 +28,13 @@ public class Lunar implements ISpellModifier{
 	@SuppressWarnings("incomplete-switch")
 	@Override
 	public float getModifier(SpellModifiers type, EntityLivingBase caster, Entity target, World world, byte[] metadata){
-		switch (type){
-		case RANGE:
-			return modifyValueOnLunarCycle(world, 3f);
-		case RADIUS:
-			return modifyValueOnLunarCycle(world, 3);
-		case DAMAGE:
-			return modifyValueOnTime(world, 2.4f);
-		case DURATION:
-			return modifyValueOnTime(world, 5f);
-		case HEALING:
-			return modifyValueOnTime(world, 2f);
-		}
-		return 1.0f;
-	}
+		ExtendedProperties properties = ExtendedProperties.For(caster);
+		float manaRatio = properties.getCurrentMana() / properties.getMaxMana();
+		float spellBonus = getSpellTypeBonus(type);
 
-	private float modifyValueOnTime(World world, float value){
-		long x = world.provider.getWorldTime() % 24000;
-		float multiplierFromTime = (float)(Math.sin(((x / 4600f) * (x / 21000f) - 900f) * (180f / Math.PI)) * 3f) + 1;
-		if (multiplierFromTime < 0)
-			multiplierFromTime *= -0.5f;
-		return value * multiplierFromTime;
-	}
-
-	private float modifyValueOnLunarCycle(World world, float value){
-		long boundedTime = world.provider.getWorldTime() % 24000;
-		int phase = 8 - world.provider.getMoonPhase(world.getWorldInfo().getWorldTime());
-		if (boundedTime > 12500 && boundedTime < 23500){
-			return value + (phase / 2);
-		}
-		return Math.abs(value - 1);
+		return (float) Math.max(1,
+				Math.pow(Math.pow((manaRatio * spellBonus), (manaRatio+1)),(manaRatio+1))
+		);
 	}
 
 	@Override
@@ -69,12 +48,40 @@ public class Lunar implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
-		return 4.0f * quantity;
-	}
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
+		World world = caster.worldObj;
+		long time = world.getWorldTime();
 
+		float multiplier = 3.5f;
+
+		if (caster.dimension == 1)
+			multiplier = 2.0f;
+		else if (!world.provider.hasNoSky && time > 13000){
+			//Returns a decreasing value between 3.4 and 2.5 as it approaches midnight.
+			multiplier = (float) Math.round(
+					(1.5 + Math.exp(0.13 * (Math.abs((time - 18000)/1000))))
+							* 100)/100;
+		}
+		return quantity * multiplier;
+	}
 	@Override
 	public byte[] getModifierMetadata(ItemStack[] matchedRecipe){
 		return null;
 	}
+	public float getSpellTypeBonus(SpellModifiers type){
+		switch (type){
+		case HEALING:
+			return 1.3f; //bonus at 100% = 286%
+		case DAMAGE:
+			return 1.4f; //bonus at 100% = 384%
+		case RADIUS:
+			return 1.5f; //bonus at 100% = 500%
+		case RANGE:
+			return 1.6f; //bonus at 100% = 655%
+		case DURATION:
+			return 1.7f; //bonus at 100% = 835%
+		}
+		return 1.2f; //bonus at 100% = 207%
+	}
+
 }

--- a/src/main/java/am2/spell/modifiers/MiningPower.java
+++ b/src/main/java/am2/spell/modifiers/MiningPower.java
@@ -36,7 +36,7 @@ public class MiningPower implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/MissingModifier.java
+++ b/src/main/java/am2/spell/modifiers/MissingModifier.java
@@ -32,7 +32,7 @@ public class MissingModifier implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Piercing.java
+++ b/src/main/java/am2/spell/modifiers/Piercing.java
@@ -38,7 +38,7 @@ public class Piercing implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.5f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Prosperity.java
+++ b/src/main/java/am2/spell/modifiers/Prosperity.java
@@ -38,7 +38,7 @@ public class Prosperity implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.25f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Radius.java
+++ b/src/main/java/am2/spell/modifiers/Radius.java
@@ -38,7 +38,7 @@ public class Radius implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 2.5f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Range.java
+++ b/src/main/java/am2/spell/modifiers/Range.java
@@ -38,7 +38,7 @@ public class Range implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.2f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/RuneProcs.java
+++ b/src/main/java/am2/spell/modifiers/RuneProcs.java
@@ -38,7 +38,7 @@ public class RuneProcs implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.65f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/Speed.java
+++ b/src/main/java/am2/spell/modifiers/Speed.java
@@ -39,7 +39,7 @@ public class Speed implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.15f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/TargetBlocks.java
+++ b/src/main/java/am2/spell/modifiers/TargetBlocks.java
@@ -40,7 +40,7 @@ public class TargetBlocks implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.05f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/TargetCreatures.java
+++ b/src/main/java/am2/spell/modifiers/TargetCreatures.java
@@ -38,7 +38,7 @@ public class TargetCreatures implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.05f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/TargetMonsters.java
+++ b/src/main/java/am2/spell/modifiers/TargetMonsters.java
@@ -40,7 +40,7 @@ public class TargetMonsters implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.05f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/TargetNonSolidBlocks.java
+++ b/src/main/java/am2/spell/modifiers/TargetNonSolidBlocks.java
@@ -42,7 +42,7 @@ public class TargetNonSolidBlocks implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1;
 	}
 

--- a/src/main/java/am2/spell/modifiers/TargetPlayers.java
+++ b/src/main/java/am2/spell/modifiers/TargetPlayers.java
@@ -38,7 +38,7 @@ public class TargetPlayers implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.05f * quantity;
 	}
 

--- a/src/main/java/am2/spell/modifiers/VelocityAdded.java
+++ b/src/main/java/am2/spell/modifiers/VelocityAdded.java
@@ -38,7 +38,7 @@ public class VelocityAdded implements ISpellModifier{
 	}
 
 	@Override
-	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity){
+	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		return 1.3f * quantity;
 	}
 


### PR DESCRIPTION
Solar = Increased power exponentially based on current burnout
![image](https://github.com/TCLProject/ArsMagica2-5/assets/47131096/69282afb-e37f-43b5-a043-07c4b8f6ffb1)

Lunar = Increased power exponentially based on mana.
![image](https://github.com/TCLProject/ArsMagica2-5/assets/47131096/2aa52a29-7a06-43b8-b1e7-733e3d706cba)

Cost of casting is dependent on time of day and dimension: 
-Solar: cheaper at midday (x2.0-x2.5) but cheapest in the Nether (x1.5)
-Lunar: cheaper at midnight (x2.5-x3.5) but cheapest in the End (x2.0)


TO-DO:
Update Arcane Compendium.

Intended lore:
__Solar:__ 
Allows you to tap into the natural magic entropy generated from stars and planets.
The more entropy you generate within yourself as burnout the more you can tap into this external force.
It should be similar to ambient mana from the Mother of Learning novel but as a mana enhancer rather than a mana supply:
https://mother-of-learning.fandom.com/wiki/Mana#Ambient_mana

__Lunar__
The lack of magic entropy increases the control over your own mana.
This "magic noise" within you allows greater efficiency of your own mana, attuning to the mind and body increasing its power.
However, this time of meditative casting is easily disrupted by imbalances in your mana capacity.