### PR TITLE
Alternative Arcane Compendium Start

### DIFF
--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -65,6 +65,7 @@ import net.minecraft.util.*;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.brewing.PotionBrewedEvent;
 import net.minecraftforge.event.entity.EntityEvent.EntityConstructing;
@@ -1512,9 +1513,8 @@ public class AMEventHandler{
 
 	@SubscribeEvent
 	public void onEntityInteract(EntityInteractEvent event){
-		if (event.target instanceof EntityItemFrame){
+		if (!(event.entityLiving instanceof FakePlayer) && event.target instanceof EntityItemFrame)
 			AMCore.proxy.itemFrameWatcher.startWatchingFrame((EntityItemFrame)event.target);
-		}
 	}
 
 	@SubscribeEvent

--- a/src/main/java/am2/ItemFrameWatcher.java
+++ b/src/main/java/am2/ItemFrameWatcher.java
@@ -8,6 +8,7 @@ import am2.particles.ParticleColorShift;
 import am2.particles.ParticleHoldPosition;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemBook;
@@ -15,6 +16,7 @@ import net.minecraft.item.ItemStack;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class ItemFrameWatcher{
 
@@ -69,11 +71,20 @@ public class ItemFrameWatcher{
 
 		EntityItemFrame frame = frameComp.frame;
 
+		List<Block> targetBlock = new ArrayList<>();
+
+		if (AMCore.config.isAlternativeStart()){
+			targetBlock.add(BlocksCommonProxy.witchwoodLeaves);
+			targetBlock.add(BlocksCommonProxy.witchwoodLog);
+		} else {
+			targetBlock.add(BlocksCommonProxy.liquidEssence);
+		}
+
 		for (int i = -radius; i <= radius; ++i){
 			for (int j = -radius; j <= radius; ++j){
 				for (int k = -radius; k <= radius; ++k){
 
-					if (frame.worldObj.getBlock((int)frame.posX + i, (int)frame.posY + j, (int)frame.posZ + k) == BlocksCommonProxy.liquidEssence){
+					if (targetBlock.contains(frame.worldObj.getBlock((int)frame.posX + i, (int)frame.posY + j, (int)frame.posZ + k))){
 
 						Integer time = watchedFrames.get(frameComp);
 						if (time == null){

--- a/src/main/java/am2/configuration/AMConfig.java
+++ b/src/main/java/am2/configuration/AMConfig.java
@@ -64,6 +64,8 @@ public class AMConfig extends Configuration{
 	private final String KEY_EverstoneRepairRate = "EverstoneRepairRate";
 
 	private final String KEY_witchwoodLeavesFall = "WitchwoodLeafParticles";
+	private final String KEY_alternativeStart = "AlternativeStart";
+
 	private final String KEY_CandlesAreRovingLights = "CandlesAreRovingLights";
 	private final String KEY_Appropriation_Block_Blacklist = "Appropriation_Block_Blacklist";
 	private final String KEY_Appropriation_Mob_Blacklist = "Appropriation_Mob_Blacklist";
@@ -206,6 +208,7 @@ public class AMConfig extends Configuration{
 	private boolean suggestSpellNames;
 	private boolean forgeSmeltsVillagers;
 	private boolean witchwoodLeafParticles;
+	private boolean alternativeStart;
 	private boolean debugVortex;
 	private int everstoneRepairRate;
 
@@ -372,6 +375,7 @@ public class AMConfig extends Configuration{
 		mmfBiomeID = get(CATEGORY_GENERAL, KEY_MMFBiomeID, 110, "The biome ID for Moo Moo Farm. Change this if you run into issues with other mods that add biomes.").getInt();
 		mmfDimensionID = get(CATEGORY_GENERAL, KEY_MMFDimensionID, -31, "The dimension ID for Moo Moo Farm. Change this if you run into issues with other mods that add dimensions.").getInt();
 		witchwoodLeafParticles = get(CATEGORY_GENERAL, KEY_witchwoodLeavesFall, true, "Disable this if you experience low FPS in witchwood forests").getBoolean(true);
+		alternativeStart = get(CATEGORY_GENERAL, KEY_alternativeStart, false, "Arcane Compendium creation requires Witchwood Trees instead of Ethereum Lakes").getBoolean(false);
 		debugVortex = get(CATEGORY_GENERAL, KEY_DebugVortex, false, "Enable if you're having issues with spatial vortices and want to report it. This enables a lot of verbose output about their inner workings at all stages to make it easier for me to debug.").getBoolean(false);
 		enableWitchwoodForest = get(CATEGORY_GENERAL, KEY_EnableWitchwoodForest, true, "Disable this if you prefer the witchwood forest to not generate").getBoolean(true);
 		witchwoodForestRarity = get(CATEGORY_GENERAL, KEY_WitchwoodForestRarity, 6, "Sets how rare witchwood forests are.  Lower is more rare.").getInt();
@@ -742,6 +746,10 @@ public class AMConfig extends Configuration{
 	public boolean witchwoodLeafPFX(){
 		return witchwoodLeafParticles;
 	}
+	public boolean isAlternativeStart(){
+		return alternativeStart;
+	}
+
 
 	public boolean colourblindMode(){
 		return colourblindMode;


### PR DESCRIPTION
New config:
**alternativeStart**
"When enabled, the Arcane Compendium creation requires Witchwood Trees instead of Ethereum Lakes".
![AltStart](https://github.com/TCLProject/ArsMagica2-5/assets/47131096/fdd5996b-ee49-4d00-99dc-d10cc9e18b22)

I've also added a FakePlayer check for extreme rare cases optimizations in the item frame interaction.