### PR TITLE
Fixed Solar and Lunar

### DIFF
--- a/src/main/java/am2/spell/modifiers/Lunar.java
+++ b/src/main/java/am2/spell/modifiers/Lunar.java
@@ -50,17 +50,18 @@ public class Lunar implements ISpellModifier{
 	@Override
 	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		World world = caster.worldObj;
-		long time = world.getWorldTime();
 
 		float multiplier = 3.5f;
 
 		if (caster.dimension == 1)
 			multiplier = 2.0f;
-		else if (!world.provider.hasNoSky && time > 13000){
+		else if (!world.provider.hasNoSky && !world.isDaytime()){
+			double time = world.getWorldTime() % 24000;
+
 			//Returns a decreasing value between 3.4 and 2.5 as it approaches midnight.
-			multiplier = (float) Math.round(
-					(1.5 + Math.exp(0.13 * (Math.abs((time - 18000)/1000))))
-							* 100)/100;
+			multiplier = (float)Math.round((
+					1.5 + Math.exp(0.13 * (Math.abs((time - 18000) / 1000)))
+			) * 100) / 100;
 		}
 		return quantity * multiplier;
 	}

--- a/src/main/java/am2/spell/modifiers/Solar.java
+++ b/src/main/java/am2/spell/modifiers/Solar.java
@@ -47,13 +47,13 @@ public class Solar implements ISpellModifier{
 	@Override
 	public float getManaCostMultiplier(ItemStack spellStack, int stage, int quantity, EntityLivingBase caster){
 		World world = caster.worldObj;
-		long time = world.getWorldTime();
-
 		float multiplier = 2.5f;
 
 		if (caster.dimension == -1)
 			multiplier = 1.5f;
-		else if (!world.provider.hasNoSky && time < 13000){
+		else if (!world.provider.hasNoSky && world.isDaytime()){
+			double time = world.getWorldTime() % 24000;
+
 			//Returns a decreasing value between 2.4 and 2.0 as it approaches midday.
 			multiplier = (float) Math.round((
 					1.0f + Math.exp(0.058 * (Math.abs((time - 6000)/1000)))


### PR DESCRIPTION
`getWorldTime()` returns the total time of the dimension, not its current time in ticks unlike I expected.

It makes the whole calculations for Solar and Lunar go out of whack after the first day is over.

This is fixed by applying a 24000 Modulus operator to it.
