### PR TITLE
fix GUI crash when missing component appears

### DIFF
--- a/src/main/java/am2/guis/GuiInscriptionTable.java
+++ b/src/main/java/am2/guis/GuiInscriptionTable.java
@@ -412,8 +412,10 @@ public class GuiInscriptionTable extends GuiContainer{
 		//main recipe
 		for (int i = 0; i < ((ContainerInscriptionTable)this.inventorySlots).getCurrentRecipeSize(); ++i){
 			ISpellPart part = ((ContainerInscriptionTable)this.inventorySlots).getRecipeItemAt(i);
-			if (part == SkillManager.instance.missingShape)
+			// missingShape, missingComponent, missingModifier check. Temporary solution until someone figures out a good API.
+			if (SkillManager.instance.getSkillName(part) == null){
 				continue;
+			}
 			String name = SkillManager.instance.getDisplayName(part);
 
 			if (drawIcon(part, false)){
@@ -429,6 +431,10 @@ public class GuiInscriptionTable extends GuiContainer{
 		for (int i = 0; i < ((ContainerInscriptionTable)this.inventorySlots).getNumStageGroups(); ++i){
 			for (int n = 0; n < ((ContainerInscriptionTable)this.inventorySlots).getShapeGroupSize(i); ++n){
 				ISpellPart part = ((ContainerInscriptionTable)this.inventorySlots).getShapeGroupPartAt(i, n);
+				// missingShape, missingComponent, missingModifier check. Temporary solution until someone figures out a good API.
+				if (SkillManager.instance.getSkillName(part) == null) {
+					continue;
+				}
 				String name = SkillManager.instance.getDisplayName(part);
 
 				int SGX = shapeGroupX + ((shapeGroupWidth + shapeGroupPadding) * i) + 1;
@@ -449,13 +455,9 @@ public class GuiInscriptionTable extends GuiContainer{
 	}
 
 	private boolean drawAvailableParts(ArrayList<String> labelText){
-
 		iconX = IIconXStart_upper;
 		iconY = IIconYStart_upper;
-
-		boolean b = drawPartIcons(labelText);
-
-		return b;
+		return drawPartIcons(labelText);
 	}
 
 	private boolean drawPartIcons(ArrayList<String> labelText){
@@ -471,9 +473,10 @@ public class GuiInscriptionTable extends GuiContainer{
 		for (Integer i : ids){
 			ISkillTreeEntry part = SkillManager.instance.getSkill(i);
 
-			if (part != null && SkillTreeManager.instance.isSkillDisabled(part))
+			// skip if part is null (how?), !if it's missingShape, missingComponent, missingModifier!, or disabled in config
+			if (part == null || SkillManager.instance.getSkillName(part) == null || SkillTreeManager.instance.isSkillDisabled(part)){
 				continue;
-
+			}
 			String name = SkillManager.instance.getDisplayName(part);
 
 			String filterText = searchBar.getText().toLowerCase();


### PR DESCRIPTION
Fixes #27 crash, but still needed some API to deal with missing shapes at a first place (auto-delete them from spells or draw them like errors like am2pg did, idk)