### PR TITLE
Only Reconstruct Repairable Items

### DIFF
--- a/src/main/java/am2/blocks/tileentities/TileEntityArcaneReconstructor.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityArcaneReconstructor.java
@@ -275,7 +275,7 @@ public class TileEntityArcaneReconstructor extends TileEntityAMPower implements 
 			return true;
 		}
 
-		if (inventory[SLOT_ACTIVE].isItemDamaged()){
+		if (inventory[SLOT_ACTIVE].isItemDamaged() && inventory[SLOT_ACTIVE].getItem().isRepairable()){
 			if (!worldObj.isRemote)
 				inventory[SLOT_ACTIVE].damageItem(-1, getDummyEntity());
 			return true;


### PR DESCRIPTION
Reconstruct items only if repair crafting hasn't been intentionally disabled by mods.

Repair crafting is the process of merging two damaged items at a crafting table to merge their durability, which is enabled for all damageable items by default.

However, mods may deliberately disable this on specific items by calling the `setNoRepair()` method. 
Typically, this is done for items with unique repair mechanics, like energy recharge or partaking in rituals.

This PR will make it so that the Arcane Reconstructor respects that.